### PR TITLE
Fix typo on blog model

### DIFF
--- a/app/models/blog.js
+++ b/app/models/blog.js
@@ -9,7 +9,7 @@ const blogSchema = new mongoose.Schema({
   },
   content:{
     type: String,
-    require: true
+    required: true
   },
   _owner: {
     type: mongoose.Schema.Types.ObjectId,


### PR DESCRIPTION
Fixed a typo on the blog model where 'required: true' was typed as
'require: true'.